### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Underscoreドキュメント日本語訳
+# Underscoreドキュメント日本語訳
 
 部分的な翻訳済みドキュメントを集めていって、翻訳カバー率100%を目指します。
 Pull Request・Issue・ご寄稿・ご指摘、いずれも歓迎しています。お気軽にどうぞ。
@@ -38,7 +38,7 @@ Markdown上で元文書の表現を再現できるようご協力ください。
 en.ja-ossプロジェクトでは現在管理者を募集しています。
 詳しくは[こちらを参照してください](https://github.com/enja-oss/README/issues/12)。
 
-##翻訳済みコンテンツ
+## 翻訳済みコンテンツ
 
 - [Intoduction](https://github.com/enja-oss/Underscore/blob/master/docs/Introduction.md)
 - [Collections](https://github.com/enja-oss/Underscore/blob/master/docs/Collection.md)
@@ -49,30 +49,30 @@ en.ja-ossプロジェクトでは現在管理者を募集しています。
 - [Chaining](https://github.com/enja-oss/Underscore/blob/master/docs/Chaining.md)
 - [Links & Suggested Reading](https://github.com/enja-oss/Underscore/blob/master/docs/Links-and-Suggested-reading.md)
 
-##着手中/予定コンテンツ
+## 着手中/予定コンテンツ
 
 - [annotated source code](http://underscorejs.org/docs/underscore.html) [@ahomu](https://github.com/ahomu)
 
-##未着手コンテンツ
+## 未着手コンテンツ
 
 - 現在着手前のコンテンツはありません
 
 コンテンツの翻訳にご協力くださる方は、ぜひ[着手予定の宣言コーナー](https://github.com/enja-oss/Underscore/issues/1)でお知らせください。
 その際に、着手予定のが他の人とかぶっていないこともご確認ください。
 
-###参照先
+### 参照先
 
 翻訳当時の[Underscore.jsのGitHubページ](http://underscorejs.org/)を参考にしています。
 そのため、その時点の本家[gh-pages](https://github.com/documentcloud/underscore/tree/gh-pages)ブランチから、コミットハッシュのtreeを辿って指定しています。
 
-##ライセンス・クレジット
+## ライセンス・クレジット
 
 本ドキュメントは、underscore.orgで公開されているものを翻訳したドキュメントです。
 原文は[Underscore.js](http://underscorejs.org/ "Underscore.js")にあります。
 
 Underscore.jsのライセンスを引き継ぎ、すべてMIT Licenseとします。
 
-##翻訳参加者
+## 翻訳参加者
 
 随時追加しています。
 

--- a/docs/Arrays.md
+++ b/docs/Arrays.md
@@ -4,7 +4,7 @@
 
 注: 全ての配列関数は、オブジェクトを引数に取ることができます。しかし、まばらな配列に対して実行できるようには設計されていません。  
 
-###first `_.first(array, [n])` _Alias: head, take_ [原文](http://underscorejs.org/#first)
+### first `_.first(array, [n])` _Alias: head, take_ [原文](http://underscorejs.org/#first)
 配列の最初の要素を返します。 **n** を与えると、配列の最初の **n** 個の要素を返します。  
 
 ```javascript
@@ -12,7 +12,7 @@ _.first([5, 4, 3, 2, 1]);
 => 5
 ```
 
-###initial `_.initial(array, [n])` [原文](http://underscorejs.org/#initial)
+### initial `_.initial(array, [n])` [原文](http://underscorejs.org/#initial)
 配列の最後の要素以外を返します。argumentsを引数に取る場合に特に便利です。 **n** を与えると、配列の最後の **n** 個の要素を返り値に含めません。  
 
 ```javascript
@@ -20,7 +20,7 @@ _.initial([5, 4, 3, 2, 1]);
 => [5, 4, 3, 2]
 ```
 
-###last `_.last(array, [n])` [原文](http://underscorejs.org/#last)
+### last `_.last(array, [n])` [原文](http://underscorejs.org/#last)
 配列の最後の要素を返します。 *n* を与えると、配列の最後の *n* 個の要素を返します。  
 
 ```javascript
@@ -28,7 +28,7 @@ _.last([5, 4, 3, 2, 1]);
 => 1
 ```
 
-###rest `_.rest(array, [index])` _Alias: tail, drop_ [原文](http://underscorejs.org/#rest)
+### rest `_.rest(array, [index])` _Alias: tail, drop_ [原文](http://underscorejs.org/#rest)
 配列の残りの要素を返します。 **index** を与えると、その index から前方にある配列の値を取得します。  
 
 ```javascript
@@ -36,7 +36,7 @@ _.rest([5, 4, 3, 2, 1]);
 => [4, 3, 2, 1]
 ```
 
-###compact `_.compact(array)` [原文](http://underscorejs.org/#compact)
+### compact `_.compact(array)` [原文](http://underscorejs.org/#compact)
 falseを振る舞う要素を除いた配列のコピーを返します。JavaScriptにおいて、false、null、0、""、undefined、そしてNaNはfalse値を振る舞います。  
 
 ```javascript
@@ -44,7 +44,7 @@ _.compact([0, 1, false, 2, '', 3]);
 => [1, 2, 3]
 ```
 
-###flatten `_.flatten(array, [shallow])` [原文](http://underscorejs.org/#flatten)
+### flatten `_.flatten(array, [shallow])` [原文](http://underscorejs.org/#flatten)
 入れ子になった配列を平坦化します(入れ子はどんな深度でも可能です)。 **shallow** 引数を渡すと、入れ子の配列は第一階層のみ平坦化されます。  
 
 ```javascript
@@ -55,7 +55,7 @@ _.flatten([1, [2], [3, [[4]]]], true);
 => [1, 2, 3, [[4]]];
 ```
 
-###without `_.without(array, [*values])` [原文](http://underscorejs.org/#without)
+### without `_.without(array, [*values])` [原文](http://underscorejs.org/#without)
 values引数で指定した値を配列から除いた配列のコピーを返します。  
 
 ```javascript
@@ -63,7 +63,7 @@ _.without([1, 2, 1, 0, 3, 1, 4], 0, 1);
 => [2, 3, 4]
 ```
 
-###union `_.union(*arrays)` [原文](http://underscorejs.org/#union)
+### union `_.union(*arrays)` [原文](http://underscorejs.org/#union)
 渡された配列群から和集合を算出します: 1つないしそれ以上の配列にある、ユニークなアイテムが順番になったリストとなります。  
 
 ```javascript
@@ -71,7 +71,7 @@ _.union([1, 2, 3], [101, 2, 1, 10], [2, 1]);
 => [1, 2, 3, 101, 10]
 ```
 
-###intersection `_.intersection(*arrays)` [原文](http://underscorejs.org/#intersection)
+### intersection `_.intersection(*arrays)` [原文](http://underscorejs.org/#intersection)
 すべての配列の共通集合となる値のリストを算出します。結果となる値はそれぞれの配列内に存在することになります。  
 
 ```javascript
@@ -79,7 +79,7 @@ _.intersection([1, 2, 3], [101, 2, 1, 10], [2, 1]);
 => [1, 2]
 ```
 
-###difference `_.difference(array, *others)` [原文](http://underscorejs.org/#difference)
+### difference `_.difference(array, *others)` [原文](http://underscorejs.org/#difference)
 _without_ 関数と似ていますが、other引数で指定した配列に存在しない値を返します。  
 
 ```javascript
@@ -87,7 +87,7 @@ _.difference([1, 2, 3, 4, 5], [5, 2, 10]);
 => [1, 3, 4]
 ```
 
-###uniq `_.uniq(array, [isSorted], [iterator])` _Alias: unique_ [原文](http://underscorejs.org/#uniq)
+### uniq `_.uniq(array, [isSorted], [iterator])` _Alias: unique_ [原文](http://underscorejs.org/#uniq)
 値の比較に"==="を使用し、ユニークな値を要素とする配列を返します。事前に配列がソートされていることがわかっていれば、 **isSorted** にtrueを与えることで、より高速に実行されます。ユニークな値を変形によって算出したい場合は **iterator** 引数に関数を渡して下さい。
 
 ```javascript
@@ -95,7 +95,7 @@ _.uniq([1, 2, 1, 3, 1, 4]);
 => [1, 2, 3, 4]
 ```
 
-###zip `_.zip(*arrays)` [原文](http://underscorejs.org/#zip)
+### zip `_.zip(*arrays)` [原文](http://underscorejs.org/#zip)
 それぞれの配列を同じ場所にある値を元に結合します。配列のインデックスを通じて強調している分離したデータソースを扱う場合に便利です。入れ子になった配列のマトリックスを使用する場合、 **zip.apply** を利用することで同様に結合することができます。
 
 ```javascript
@@ -103,7 +103,7 @@ _.zip(['moe', 'larry', 'curly'], [30, 40, 50], [true, false, false]);
 => [["moe", 30, true], ["larry", 40, false], ["curly", 50, false]]
 ```
 
-###object `_.object(list, [values])` [原文](http://underscorejs.org/#object)
+### object `_.object(list, [values])` [原文](http://underscorejs.org/#object)
 配列をオブジェクトに変換します。`[key, value]`のペアとなる1つのリスト、もしくはkeysのリストとvaluesのリスト、どちらかを引数として渡してください。  
 
 ```javascript
@@ -114,7 +114,7 @@ _.object([['moe', 30], ['larry', 40], ['curly', 50]]);
 => {moe: 30, larry: 40, curly: 50}
 ```
 
-###indexOf `_.indexOf(array, value, [isSorted])` [原文](http://underscorejs.org/#indexOf)
+### indexOf `_.indexOf(array, value, [isSorted])` [原文](http://underscorejs.org/#indexOf)
 value引数で指定した値のある配列のインデックスを返します。配列に存在しない場合は-1を返します。ネイティブの indexOf 関数がある場合はそれを使用します。大きな配列を扱い場合、かつ配列がソートされている場合には、 **isSorted** に `true`を与えることでより高速なバイナリサーチを行います。あるいは、第三引数に数字を渡すことでそのインデックス移行から探索を行います。
 
 ```javascript
@@ -122,7 +122,7 @@ _.indexOf([1, 2, 3], 2);
 => 1
 ```
 
-###lastIndexOf `_.lastIndexOf(array, value, [fromIndex])` [原文](http://underscorejs.org/#lastIndexOf)
+### lastIndexOf `_.lastIndexOf(array, value, [fromIndex])` [原文](http://underscorejs.org/#lastIndexOf)
 value引数で指定した値のある配列の最後のインデックスを取得します。配列中に存在しない場合-1を返します。ネイティブの lastIndexOf 関数がある場合はそれを使用します。 **fromIndex** を与えると、そのインデックスから探索をします。  
 
 ```javascript
@@ -130,7 +130,7 @@ _.lastIndexOf([1, 2, 3, 1, 2, 3], 2);
 => 4
 ```
 
-###sortedIndex `_.sortedIndex(list, value, [iterator])` [原文](http://underscorejs.org/#sortedIndex)
+### sortedIndex `_.sortedIndex(list, value, [iterator])` [原文](http://underscorejs.org/#sortedIndex)
 value引数に渡された値がリストのソート済みの順序を保持できるようにインデックスのどの位置に挿入されるべきかをバイナリサーチを利用して測定します。 **iterator** が渡された場合、渡した値を含めて、それぞれの値のソート順序を算出します。  
 
 ```javascript
@@ -138,7 +138,7 @@ _.sortedIndex([10, 20, 30, 40, 50], 35);
 => 3
 ```
 
-###range `_.range([start], stop, [step])` [原文](http://underscorejs.org/#range)
+### range `_.range([start], stop, [step])` [原文](http://underscorejs.org/#range)
 柔軟に番号付けされた整数のリストを生成する関数です。eachとmapのループ内で便利に利用できます。start引数が省略された場合は0がデフォルト値、stepのデフォルト値は1となります。startからstopまでの、stepずつインクリメント（またはデクリメント）された数字の配列を返します。排他処理。  
 
 ```javascript

--- a/docs/Utility.md
+++ b/docs/Utility.md
@@ -2,7 +2,7 @@
 
 ## Utility Functions [原文](http://underscorejs.org/#utility)
 
-###noConflict `_.noConflict()` [原文](http://underscorejs.org/#noConflict)
+### noConflict `_.noConflict()` [原文](http://underscorejs.org/#noConflict)
 
 競合以前の”_”変数に対するコントロールを提供します。 **Underscore** オブジェクトへの参照が返されます。
 
@@ -10,7 +10,7 @@
 var underscore = _.noConflict();
 ```
 
-###identity `_.identity(value)` [原文](http://underscorejs.org/#identity)
+### identity `_.identity(value)` [原文](http://underscorejs.org/#identity)
 
 引数として渡された値と同じ値を返します。数学的に表現すると `f(x) = x` となります。
 この関数は役に立たないように見えますが、Underscore全体でデフォルトのイテレータとして使用しています。
@@ -21,7 +21,7 @@ moe === _.identity(moe);
 => true
 ```
 
-###times `_.times(n, iterator, [context])` [原文](http://underscorejs.org/#times)
+### times `_.times(n, iterator, [context])` [原文](http://underscorejs.org/#times)
 
 渡された **iterator** 関数を **n** 回呼び出します。それぞれの **iterator** 呼び出しは、引数（context）の `index` と共に呼び出されます。
 
@@ -31,7 +31,7 @@ _注：この例では[Chaining構文](http://underscorejs.org/#chaining)を使�
 _(3).times(function(n){ genie.grantWishNumber(n); });
 ```
 
-###random `_.random(min, max)` [原文](http://underscorejs.org/#random)
+### random `_.random(min, max)` [原文](http://underscorejs.org/#random)
 
 **min** 以上 **max** 以下の範囲でランダムな整数値を返します。引数を1つだけ渡した場合は、`0` から渡された値までの数値を返します。
 
@@ -40,7 +40,7 @@ _.random(0, 100);
 => 42
 ```
 
-###mixin `_.mixin(object)` [原文](http://underscorejs.org/#mixin)
+### mixin `_.mixin(object)` [原文](http://underscorejs.org/#mixin)
 
 Underscoreはあなた独自のutility関数を含める形で拡張することを許しています。`{name: function}` ハッシュを満たすように定義することで、独自の関数をOOP（オブジェクト指向プログラミング）ラッパーのように、Underscoreオブジェクトへ追加できます。
 
@@ -54,7 +54,7 @@ _("fabio").capitalize();
 => "Fabio"
 ```
 
-###uniqueId `_.uniqueId([prefix])` [原文](http://underscorejs.org/#uniqueId)
+### uniqueId `_.uniqueId([prefix])` [原文](http://underscorejs.org/#uniqueId)
 
 クライアント側のモデルまたはDOM要素のいずれかが必要な、グローバルなユニークIDを生成します。引数に **prefix** を渡した場合、IDが後ろに付きます。
 
@@ -63,7 +63,7 @@ _.uniqueId('contact_');
 => 'contact_104'
 ```
 
-###escape `_.escape(string)` [原文](http://underscorejs.org/#escape)
+### escape `_.escape(string)` [原文](http://underscorejs.org/#escape)
 
 HTMLに挿入するため、次の文字列をエスケープします。 `&` 、 `<` 、 `>` 、 `"` 、 `'` 、 `/`。
 
@@ -72,7 +72,7 @@ _.escape('Curly, Larry & Moe');
 => "Curly, Larry &amp; Moe"
 ```
 
-###unescape `_.unescape(string)` [原文](http://underscorejs.org/#unescape)
+### unescape `_.unescape(string)` [原文](http://underscorejs.org/#unescape)
 
 **[escape](http://underscorejs.org/#escape)** と反対で、上と対をなす文字列をエスケープされていない文字に置き換えます。 `&amp;` 、 `&lt;` 、 `&gt;` 、 `&quot;`、 `&#x27;` 、 
  `&#x2F;`
@@ -83,7 +83,7 @@ _.escape('Curly, Larry &amp; Moe');
 => "Curly, Larry & Moe"
 ```
 
-###result `_.result(object, property)` [原文](http://underscorejs.org/#result)
+### result `_.result(object, property)` [原文](http://underscorejs.org/#result)
 
 プロパティの値が関数の場合は、それを実行し、そうでなければプロパティ値を返します。
 
@@ -95,7 +95,7 @@ _.result(object, 'stuff');
 => "nonsense"
 ```
 
-###template `_.template(templateString, [data], [settings])` [原文](http://underscorejs.org/#template)
+### template `_.template(templateString, [data], [settings])` [原文](http://underscorejs.org/#template)
 
 レンダリング用に評価するためJavaScriptテンプレートをコンパイルして関数化を行います。
 JSONデータソースから複雑なHTMLの断片をレンダリングするために便利です。


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
